### PR TITLE
Updates

### DIFF
--- a/pmd.xml
+++ b/pmd.xml
@@ -4,13 +4,14 @@
          name="PMD Ruleset"
 >
     <description>
-        This ruleset is adapted from the default maven PMG plugin ruleset which can be found here:
+        This ruleset is adapted from the default maven PMD plugin ruleset which can be found here:
         https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/main/resources/rulesets/java/maven-pmd-plugin-default.xml;hb=HEAD
         It contains the rules of the old (pre PMD 6.0.0) rulesets java-basic, java-empty, java-imports,
         java-unnecessary, java-unusedcode. (see https://pmd.github.io/latest/pmd_userdocs_making_rulesets.html)
     </description>
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
     <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+    <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
@@ -57,5 +58,4 @@
     <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
     <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
     <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
-    <rule ref="category/java/performance.xml/BooleanInstantiation"/>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
 
     <groupId>co.luminositylabs.oss.arquillian</groupId>


### PR DESCRIPTION
- parent project luminositylabs-oss-parent updated from v0.2.1 to v0.2.2-SNAPSHOT
- pmd configuration update to replace BooleanInstantiation performance rule with PrimitiveWrapperInstantiation bestpractice rule