### PR TITLE
Updates

### DIFF
--- a/luminositylabs-arquillian-drone/pom.xml
+++ b/luminositylabs-arquillian-drone/pom.xml
@@ -19,7 +19,7 @@
         <pmd.skip>true</pmd.skip>
         <spotbugs.skip>true</spotbugs.skip>
         <!-- Dependency versions -->
-        <dependency.arquillian-drone.version>2.5.4</dependency.arquillian-drone.version>
+        <dependency.arquillian-drone.version>2.5.5</dependency.arquillian-drone.version>
         <dependency.gson.version>2.8.9</dependency.gson.version>
         <dependency.luminositylabs-selenium-bom.version>0.1.10-SNAPSHOT</dependency.luminositylabs-selenium-bom.version>
     </properties>

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -143,7 +143,8 @@
              referenced from arquillian-bom v1.6.0.Final -->
         <rule groupId="ch.qos.logback" artifactId="logback-classic" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.2\.[1-8]</ignoreVersion>
+                <ignoreVersion type="regex">1\.2\.10</ignoreVersion>
+                <ignoreVersion type="regex">1\.2\.[0-9]</ignoreVersion>
                 <ignoreVersion type="regex">.*-groovyless</ignoreVersion>
             </ignoreVersions>
         </rule>


### PR DESCRIPTION
- arquillian-drone updated from v2.5.4 to v2.5.5
- update ignore rules for logback in maven-version-rules.xml